### PR TITLE
fix default resources

### DIFF
--- a/aiida_ddec/calculations/__init__.py
+++ b/aiida_ddec/calculations/__init__.py
@@ -80,17 +80,11 @@ class DdecCalculation(CalcJob):
             required=False,
             help='Use a remote folder (for restarts and similar)',
         )
-        spec.input('metadata.options.parser_name', valid_type=six.string_types, default='ddec')
-        spec.input('metadata.options.withmpi', valid_type=bool, default=False)
-        spec.input(
-            'metadata.options.resources',
-            valid_type=dict,
-            default={
-                'num_machines': 1,
-                'num_mpiprocs_per_machine': 1,
-                'tot_num_mpiprocs': 1,
-            }
-        )
+        spec.inputs['metadata']['options']['parser_name'].default = 'ddec'
+        spec.inputs['metadata']['options']['resources'].default = {
+            'num_machines': 1,
+        }
+        spec.inputs['metadata']['options']['withmpi'].default = False
 
         #  exit codes
         spec.exit_code(


### PR DESCRIPTION
fix #18 

There are both serial and parallel versions of the chargemol code, i.e.
one should not set the number of tasks per machine to 1.
However, chargemol is not MPI-parallelized, i.e. we keep withmpi=False
and num_machines 1.