### PR TITLE
enable setting atomic density path as code extra

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 # modernizer: make sure our code-base is Python 3 ready
 - repo: https://github.com/python-modernize/python-modernize.git
-  sha: a234ce4e185cf77a55632888f1811d83b4ad9ef2
+  rev: a234ce4e185cf77a55632888f1811d83b4ad9ef2
   hooks:
   - id: python-modernize
     exclude: ^docs/

--- a/setup.json
+++ b/setup.json
@@ -39,7 +39,8 @@
   "reentry_register": true,
   "install_requires": [
     "aiida_core >= 1.0.0b6",
-    "six"
+    "six",
+    "voluptuous"
   ],
   "extras_require": {
     "cp2k":[


### PR DESCRIPTION
fixes #16

The chargemol input files contain a path to a directory with atomic
densities. Unfortunately this makes chargemol input files completely
unportable, and means that one needs to change the input file if one
changes computer.

This PR adds a possibility to set a "DDEC_ATOMIC_DENSITIES_DIRECTORY"
extra on the ddec code.
The CalcJob input plugin will look for this extra if the location of the
densities is not otherwise specified.

Furthermore, we now validate the input dictionary using voluptuous
schemas.