### PR TITLE
updates for aiida 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Install python dependencies
       run: |
         pip install --upgrade pip
-        pip install -e .[pre-commit,testing]
+        pip install -e .[pre-commit,testing,cp2k]
         reentry scan -r aiida
     - name: Run pre-commit
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,30 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
         backend: ['django']
+        aiida-version: ['stable', 'develop']
+
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_DB: test
+          POSTGRES_PASSWORD: ''
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+      rabbitmq:
+        image: rabbitmq:latest
+        ports:
+          - 5672:5672
+
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -18,15 +40,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install system dependencies
+    - name: Install aiida develop version
       run: |
-        wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | sudo apt-key add -
-        echo 'deb https://dl.bintray.com/rabbitmq-erlang/debian bionic erlang' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
-        echo 'deb https://dl.bintray.com/rabbitmq/debian bionic main' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
-        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
-        sudo apt update
-        sudo apt install postgresql-10 rabbitmq-server graphviz
-        sudo systemctl status rabbitmq-server.service
+        pip install git+git://github.com/aiidateam/aiida-core
+      if: ${{ matrix.aiida-version == 'develop' }}
 
     - name: Install python dependencies
       run: |
@@ -53,10 +70,10 @@ jobs:
 #    timeout-minutes: 15
 #    steps:
 #    - uses: actions/checkout@v1
-#    - name: Set up Python 3.7
+#    - name: Set up Python 3.8
 #      uses: actions/setup-python@v1
 #      with:
-#        python-version: 3.7
+#        python-version: 3.8
 #    - name: Install python dependencies
 #      run: |
 #        pip install --upgrade pip
@@ -70,10 +87,10 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install python dependencies
       run: |
         pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 # pre-commit install
 
 # modernizer: make sure our code-base is Python 3 ready
+repos:
 - repo: https://github.com/python-modernize/python-modernize.git
   rev: a234ce4e185cf77a55632888f1811d83b4ad9ef2
   hooks:

--- a/aiida_ddec/parsers/__init__.py
+++ b/aiida_ddec/parsers/__init__.py
@@ -37,7 +37,7 @@ class DdecParser(Parser):
             raise self.exit_codes.ERROR_NO_OUTPUT_FILE
 
         finished = False
-        with open(os.path.join(out_folder._repository._get_base_folder().abspath, output_file)) as file:  # pylint: disable=protected-access
+        with out_folder.open(output_file) as file:
             for line in file.readlines():
                 if 'Finished chargemol in' in line:
                     finished = True
@@ -46,11 +46,8 @@ class DdecParser(Parser):
             raise OutputParsingError('Calculation did not finish correctly')
 
         # Create CifData object from the following the file path returned by xyz2cif
-        output_cif = xyz2cif(
-            os.path.join(
-                out_folder._repository._get_base_folder().abspath, 'DDEC6_even_tempered_net_atomic_charges.xyz'
-            )
-        )
+        with out_folder.open('DDEC6_even_tempered_net_atomic_charges.xyz') as handle:
+            output_cif = xyz2cif(handle.readlines())
         self.out('structure_ddec', output_cif)
 
         return ExitCode(0)

--- a/aiida_ddec/utils/workchains.py
+++ b/aiida_ddec/utils/workchains.py
@@ -2,7 +2,6 @@
 """utils for the workchains"""
 
 from __future__ import absolute_import
-import os
 import collections
 from aiida.engine import workfunction as wf
 from aiida.orm import Dict
@@ -42,10 +41,8 @@ def extract_core_electrons(cp2k_remote_folder):
     """Read from the cp2k.out the number of core electrons (included in the
     pseudopotential) and print them as a Dict
     """
-    cp2k_out_dir = cp2k_remote_folder.creator.outputs.retrieved._repository._get_base_folder().abspath  # pylint: disable=protected-access
-    cp2k_out_file = os.path.join(cp2k_out_dir, 'aiida.out')
-    with open(cp2k_out_file) as f:  # pylint: disable=invalid-name
-        content = f.readlines()
+    with cp2k_remote_folder.creator.outputs.retrieved.open('aiida.out') as handle:
+        content = handle.readlines()
     for n_line, line in enumerate(content):
         if '- Atoms:' in line:
             n_atoms = int(line.split()[2])

--- a/aiida_ddec/utils/xyzparser.py
+++ b/aiida_ddec/utils/xyzparser.py
@@ -41,10 +41,11 @@ _atom_site_charge
 """
 
 
-def xyzparser(fname):
-    """Extract from XYZ files cell, atoms, coordinates, charges."""
-    with open(fname, 'r') as file:
-        lines = file.readlines()
+def xyzparser(lines):
+    """Extract from XYZ files cell, atoms, coordinates, charges.
+
+    :param lines: List of lines of XYZ file, e.g. result of open(filename).readlines()
+    """
 
     # Number of atoms
     natoms = int(lines[0])
@@ -79,12 +80,14 @@ def cell2angles(cell):
     return alpha, beta, gamma
 
 
-def xyz2cif(fname):
+def xyz2cif(lines):
     """
     Convert xyz file produced by DDEC program to a cif file.
+
+    :param lines: List of lines of XYZ file, e.g. result of open(filename).readlines()
     """
     # Extract important data from the xyz file
-    cell, atoms, xyz, charges = xyzparser(fname)
+    cell, atoms, xyz, charges = xyzparser(lines)
 
     # Transform cell into a,b,c and alpha, beta, gamma
     cell_a, cell_b, cell_c = cell2abc(cell)

--- a/aiida_ddec/workchains/cp2k_ddec.py
+++ b/aiida_ddec/workchains/cp2k_ddec.py
@@ -77,7 +77,8 @@ class Cp2kDdecWorkChain(WorkChain):
             ddec_inputs = AttributeDict(self.exposed_inputs(DdecCalculation, 'ddec'))
             ddec_inputs['charge_density_folder'
                        ] = self.ctx.cp2k_calc.outputs.remote_folder.creator.outputs.remote_folder
-        except Exception:  # pylint: disable=broad-except
+        except Exception as exc:  # pylint: disable=broad-except
+            self.report(f'Encountered exception "{str(exc)}" while parsing CP2K output')
             return self.exit_codes.ERROR_PARSING_CP2K_OUTPUT  # pylint: disable=no-member
 
         ddec_inputs['parameters'] = merge_Dict(ddec_inputs['parameters'], core_e)

--- a/setup.json
+++ b/setup.json
@@ -38,7 +38,7 @@
   ],
   "reentry_register": true,
   "install_requires": [
-    "aiida-core>=1.1.0,<2.0.0",
+    "aiida-core>=1.1.0,<3",
     "six",
     "voluptuous"
   ],
@@ -48,13 +48,13 @@
     ],
     "pre-commit": [
       "pre-commit~=2.2",
-      "pylint==2.6.0"
+      "pylint~=2.6.0"
     ],
     "testing": [
     "pgtest~=1.3.1",
     "aiida-testing @  git+https://github.com/ltalirz/aiida-testing@1cb17f0cc3d17f3f27ea6f92702ba1880abd03ca#egg=aiida-testing",
     "pytest-cov~=2.7",
-    "ase<3.20"
+    "pytest~=6.0"
     ]
   }
 }


### PR DESCRIPTION
 * CI: Switch to gh actions services
 * CI: bump python version from 3.7 to 3.8
 * test against aiida develop branch
 * remove use of private repository API
 * add report when cp2k output parser fails
 * relax upper aiida version constraint to <3