### PR TITLE
modify parser function to extract core electrons from cp2k-9 outfile

### DIFF
--- a/aiida_ddec/utils/workchains.py
+++ b/aiida_ddec/utils/workchains.py
@@ -44,12 +44,19 @@ def extract_core_electrons(cp2k_remote_folder):
     with cp2k_remote_folder.creator.outputs.retrieved.open('aiida.out') as handle:
         content = handle.readlines()
     for n_line, line in enumerate(content):
+        if line.startswith(' CP2K| version string:'):
+            cp2k_version = float(line.split()[5])
         if '- Atoms:' in line:
             n_atoms = int(line.split()[2])
         if 'Atom  Kind  Element       X           Y           Z' in line:
             break
-    res = {
-        e.split()[3]: round(float(e.split()[7])) for e in content[n_line + 2:n_line + n_atoms + 2]  # pylint: disable=undefined-loop-variable
-    }
+    if cp2k_version == float(9.0):
+        res = {
+            e.split()[3]: round(float(e.split()[7])) for e in content[n_line + 1:n_line + n_atoms + 1]  # pylint: disable=undefined-loop-variable
+        }
+    else:
+        res = {
+            e.split()[3]: round(float(e.split()[7])) for e in content[n_line + 2:n_line + n_atoms + 2]  # pylint: disable=undefined-loop-variable
+        }
     res = [k + ' ' + str(int(k) - int(v)) for k, v in res.items()]
     return Dict(dict={'number of core electrons': res}).store()


### PR DESCRIPTION
adjustment of the workchain parser file to extract the number of core electrons from the cp2k-9 output file. I tested it on cp2k-8.1 and cp2k-9