### PR TITLE
modify parser to extract results from cp2k9.x outfile

### DIFF
--- a/aiida_ddec/utils/workchains.py
+++ b/aiida_ddec/utils/workchains.py
@@ -45,12 +45,12 @@ def extract_core_electrons(cp2k_remote_folder):
         content = handle.readlines()
     for n_line, line in enumerate(content):
         if line.startswith(' CP2K| version string:'):
-            cp2k_version = float(line.split()[5])
+            cp2k_version = str(line.split()[5])
         if '- Atoms:' in line:
             n_atoms = int(line.split()[2])
         if 'Atom  Kind  Element       X           Y           Z' in line:
             break
-    if cp2k_version == float(9.0):
+    if cp2k_version.startswith('9.'):
         res = {
             e.split()[3]: round(float(e.split()[7])) for e in content[n_line + 1:n_line + n_atoms + 1]  # pylint: disable=undefined-loop-variable
         }


### PR DESCRIPTION
I modified the cp2k parser to extract the number of core electrons from cp2k9.x outfiles. Older cp2k versions (down to cp2k5.1) are still supported